### PR TITLE
Support handhelds with multiple SDcards

### DIFF
--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -31,7 +31,7 @@ static void controller_sdl_init(void) {
     }
 
     #ifdef TARGET_ELEC
-        if (SDL_GameControllerAddMappingsFromFile("/storage/roms/ports/sm64/controller/gamecontrollerdb.txt") < 0) {
+        if (SDL_GameControllerAddMappingsFromFile(SDL_getenv("SDL_GAMECONTROLLERCONFIG_FILE")) < 0) {
             fprintf(stderr, "SDL mapping error: %s\n", SDL_GetError());
             return;
         }


### PR DESCRIPTION
For example, when sm64 is running on a second SDcard (TF2), the path to /roms is invalid (/roms2 in that case on the R36S). Without this fix, the game loads but no gamepad controls work. The only hint is that when loading the game, the below error is thrown.

`SDL mapping error: Invalid RWops`

It's because it can't find gamecontrollerdb.txt. This fixes ArkOS. Not sure how/if a 351ELEC build is affected by this change.

A possible workaround for this would be to move the game to the 1st SDcard or maybe creating a symbolic link (e.g. /roms/ports/sm64/controller/gamecontrollerdb.txt).